### PR TITLE
Ignore scp/error_log in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .htaccess
 php53.cgi
 include/ost-config.php
+scp/error_log
 setup/cli/modules/importer
 *.sw[a-z]
 .DS_Store


### PR DESCRIPTION
Add `scp/error_log` to `.gitignore`
